### PR TITLE
Fix for "Undefined index" Notice

### DIFF
--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -220,7 +220,7 @@ class bcn_breadcrumb_trail
 	protected function post_hierarchy($id, $type, $parent = NULL)
 	{
 		//Check to see if breadcrumbs for the taxonomy of the post needs to be generated
-		if($this->opt['bpost_' . $type . '_taxonomy_display'])
+		if ( array_key_exists( 'bpost_' . $type . '_taxonomy_display', $this->opt ) )
 		{
 			//Check if we have a date 'taxonomy' request
 			if($this->opt['Spost_' . $type . '_taxonomy_type'] == 'date')


### PR DESCRIPTION
In my site, I'm applying a custom taxonomy to media library items (I know, right?). When I do that, on the item's page, I was getting an "Undefined index" notice.

Using array_key_exists() instead of just testing for the value of the key solves this.
