### PR TITLE
Fix `post_type_archive_title` filter parameters

### DIFF
--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -588,7 +588,7 @@ class bcn_breadcrumb_trail
 		{
 			//Core filter use here is ok for time being
 			//TODO: Recheck validitiy prior to each release
-			return apply_filters('post_type_archive_title', $object->labels->name);
+			return apply_filters('post_type_archive_title', $object->labels->name, $object->name);
 		}
 	}
 	/**


### PR DESCRIPTION
The `post_type_archive_title` filter has an additional parameter specifying the post type name since WordPress 3.8.

See http://adambrown.info/p/wp_hooks/hook/post_type_archive_title
