### PR TITLE
Select the Deepest Term in the Term Hierarchy for a Post

### DIFF
--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -237,7 +237,7 @@ class bcn_breadcrumb_trail
 					foreach($bcn_object as $key=>$object)
 					{
 						//We want the first term hiearchy
-						if($object->parent > 0)
+						if($object->parent > 0 and next($bcn_object)->category_parent != $object->term_id)
 						{
 							$bcn_use_term = $key;
 							//We found our first term hiearchy, can exit loop now


### PR DESCRIPTION
Only break if the current item is not parent of next item.

For example if the post category is: Blog --> News --> Sport. When "if($object->parent > 0)" check News parent, because "if($object->parent > 0)" is true the 'break;' line break the 'foreach'.  but in this case we must go to the next because the 'Sport' is the real trail.