### PR TITLE
multilingual plugin support (e.g. polylang)

### DIFF
--- a/breadcrumb-navxt.php
+++ b/breadcrumb-navxt.php
@@ -42,6 +42,7 @@ if(version_compare(phpversion(), '5.3.0', '<'))
 	return;
 }
 require_once(dirname(__FILE__) . '/includes/multibyte_supplicant.php');
+require_once(dirname(__FILE__) . '/includes/multilingual_helper.php');
 //Include admin base class
 if(!class_exists('mtekk_adminKit'))
 {

--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -771,6 +771,8 @@ class bcn_breadcrumb_trail
 			if(is_numeric($this->opt['apost_' . $type_str . '_root']))
 			{
 				$root_id = $this->opt['apost_' . $type_str . '_root'];
+				// translate root id
+				$root_id = bcn_translate_page_id($root_id);
 			}
 		}
 		//For CPT archives
@@ -787,6 +789,8 @@ class bcn_breadcrumb_trail
 			if(is_numeric($this->opt['apost_' . $type_str . '_root']))
 			{
 				$root_id = $this->opt['apost_' . $type_str . '_root'];
+				// translate root id
+				$root_id = bcn_translate_page_id($root_id);
 			}
 		}
 		//We need to do special things for custom post type archives, but not author or date archives
@@ -798,6 +802,8 @@ class bcn_breadcrumb_trail
 			if(is_numeric($this->opt['apost_' . $type_str . '_root']))
 			{
 				$root_id = $this->opt['apost_' . $type_str . '_root'];
+				// translate root id
+				$root_id = bcn_translate_page_id($root_id);
 			}
 		}
 		else

--- a/includes/multilingual_helper.php
+++ b/includes/multilingual_helper.php
@@ -1,0 +1,34 @@
+<?php
+/*  
+	A small library that adds multilingual plugin support (e.g. polylang).
+	Mainly inteneded to be used with Breadcrumb NavXT
+
+	Copyright 2009-2016  Andreas Stefl  (email : stefl.andreas@gmail.com)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+require_once(dirname(__FILE__) . '/block_direct_access.php');
+
+function bcn_translate_page_id($page_id)
+{
+	$query = new WP_Query( array(
+		'posts_per_page' => -1,
+		'post_type'      => 'page',
+		'post__in'       => array( $page_id ),
+		'orderby'        => 'post__in'
+	) );
+	if (!$query->have_posts()) return $page_id;
+	return $query->post->ID;
+}


### PR DESCRIPTION
I use the polylang plugin to translate a website. I also use custom post types to view different kind of information. On a single page from such an post type the root page is displayed right only for a single page, which was selected in the settings.
This modification uses a common function to get the translated page.