### PR TITLE
Fix for broken display_list after 6.0.0

### DIFF
--- a/breadcrumb-navxt.php
+++ b/breadcrumb-navxt.php
@@ -414,7 +414,7 @@ class breadcrumb_navxt
 		}
 		//Generate the breadcrumb trail
 		$this->breadcrumb_trail->fill();
-		return $this->breadcrumb_trail->display($return, $linked, $reverse);
+		return $this->breadcrumb_trail->display($return, $linked, $reverse, $template);
 	}
 	/**
 	 * Outputs the breadcrumb trail with each element encapsulated with li tags


### PR DESCRIPTION
The "template" parameter was not passed on to breacrumb_trail::display.