### PR TITLE
Update class.bcn_breadcrumb_trail.php

### DIFF
--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -979,7 +979,7 @@ class bcn_breadcrumb_trail
 	 */
 	public function fill()
 	{
-		global $wpdb, $wp_query, $wp;
+		global $wpdb, $wp_query, $wp, $wp_taxonomies;
 		//Check to see if the trail is already populated
 		if(count($this->breadcrumbs) > 0)
 		{


### PR DESCRIPTION
When viewing the product-category  term link , it was throwing an error of undefined wp_taxonomies variable, so i analyzed my code and couldn't find anything wrong then i move to the plugin file  class.bcn_breadcrumb_trail.php went to the line no 1102 and found that wp_taxonomies variable is not defined.