### PR TITLE
adding a `bcn_before_loop` filter hook

### DIFF
--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -1231,11 +1231,12 @@ class bcn_breadcrumb_trail
 	 */
 	protected function display_loop($linked, $reverse, $template)
 	{
+		$breadcrumbs = apply_filters( 'bcn_before_loop', $this->breadcrumbs );
 		$position = 1;
-		$last_position = count($this->breadcrumbs);
+		$last_position = count($breadcrumbs);
 		//Initilize the string which will hold the assembled trail
 		$trail_str = '';
-		foreach($this->breadcrumbs as $key => $breadcrumb)
+		foreach($breadcrumbs as $key => $breadcrumb)
 		{
 			$types = $breadcrumb->get_types();
 			array_walk($types, 'sanitize_html_class');


### PR DESCRIPTION
This allows to do modifications in a similar way that `bcn_after_fill` does, but apply them only to a particular render of the breadcrumbs. That is especially useful if you need to do something different when you have more than one instance of breadcrumbs of the page, i.e. one at the top and one at the bottom.