### PR TITLE
Skip empty breadcrumbs in the trail

### DIFF
--- a/class.bcn_breadcrumb_trail.php
+++ b/class.bcn_breadcrumb_trail.php
@@ -1287,7 +1287,12 @@ class bcn_breadcrumb_trail
 				$attribs = apply_filters('bcn_display_attributes', $attribs, $breadcrumb->get_types(), $breadcrumb->get_id());
 				$separator = apply_filters('bcn_display_separator', $separator, $position, $last_position, $depth);
 				//Assemble the breadcrumb
-				$trail_str .= sprintf($template, $breadcrumb->assemble($linked, $position, ($key === 0)), $separator, $attribs);
+				$assembled_breadcrumb = $breadcrumb->assemble($linked, $position, ($key === 0));
+				//If the breadcrumb is not empty, add it to the trail string
+				if($assembled_breadcrumb !== '')
+				{
+					$trail_str .= sprintf($template, $assembled_breadcrumb, $separator, $attribs);
+				}
 			}
 			if($reverse)
 			{


### PR DESCRIPTION
This change might not be necessary for most users, as it seems rare to encounter empty breadcrumb levels.
However, in a specific rare case I encountered, an empty breadcrumb level led to separators being rendered consecutively, like `> >`.
This change was needed to prevent that.
If this change is deemed valuable, I'd appreciate it being merged.
However, if it's considered unnecessary after an objective review, feel free to close the pull request.
