### PR TITLE
Guard missing postId block context

### DIFF
--- a/includes/blocks/build/breadcrumb-trail/render.php
+++ b/includes/blocks/build/breadcrumb-trail/render.php
@@ -14,9 +14,10 @@ if($attributes['hideonHome'] === true && is_front_page() && !(is_paged() && $GLO
 	return;
 }
 //Handle in-editor previews, function check to prevent requiring WP6.5
-if(function_exists('wp_is_serving_rest_request') && wp_is_serving_rest_request() && current_user_can('read_post', absint($block->context['postId'])))
+$post_id = isset($block->context['postId']) ? absint($block->context['postId']) : 0;
+if(function_exists('wp_is_serving_rest_request') && wp_is_serving_rest_request() && $post_id > 0 && current_user_can('read_post', $post_id))
 {
-	$preview_post = get_post(absint($block->context['postId']));
+	$preview_post = get_post($post_id);
 	if($attributes['format'] === 'list')
 	{
 		$template = "<li%3\$s>%1\$s</li>\n";

--- a/includes/blocks/src/breadcrumb-trail/render.php
+++ b/includes/blocks/src/breadcrumb-trail/render.php
@@ -14,9 +14,10 @@ if($attributes['hideonHome'] === true && is_front_page() && !(is_paged() && $GLO
 	return;
 }
 //Handle in-editor previews, function check to prevent requiring WP6.5
-if(function_exists('wp_is_serving_rest_request') && wp_is_serving_rest_request() && current_user_can('read_post', absint($block->context['postId'])))
+$post_id = isset($block->context['postId']) ? absint($block->context['postId']) : 0;
+if(function_exists('wp_is_serving_rest_request') && wp_is_serving_rest_request() && $post_id > 0 && current_user_can('read_post', $post_id))
 {
-	$preview_post = get_post(absint($block->context['postId']));
+	$preview_post = get_post($post_id);
 	if($attributes['format'] === 'list')
 	{
 		$template = "<li%3\$s>%1\$s</li>\n";


### PR DESCRIPTION
## Summary

This change guards the breadcrumb trail block renderer against a missing `postId` entry in `$block->context` during REST/editor rendering.

## Root cause

`render.php` accessed `$block->context['postId']` unconditionally. When the block is rendered without that context, PHP 8 emits `Undefined array key "postId"` warnings.

## Change

- read `postId` once into `$post_id`
- default to `0` when the context key is absent
- only run the preview permission and `get_post()` path when `$post_id > 0`

## Validation

- `php -l includes/blocks/build/breadcrumb-trail/render.php`
- `php -l includes/blocks/src/breadcrumb-trail/render.php`

## Impact

This removes repeated warning log entries without changing behavior for valid preview requests that do include a `postId` context.
