### PR TITLE
Fix: use esc_url() instead of esc_attr() on form action URL

### DIFF
--- a/class.bcn_admin.php
+++ b/class.bcn_admin.php
@@ -447,7 +447,7 @@ class bcn_admin extends adminKit
 			return;
 		}
 		?>
-		<form action="<?php echo esc_attr($this->admin_url()); ?>" method="post" id="bcn_admin-options">
+		<form action="<?php echo esc_url($this->admin_url()); ?>" method="post" id="bcn_admin-options">
 			<?php settings_fields('bcn_options');?>
 			<div id="hasadmintabs">
 			<fieldset id="general" class="bcn_options">


### PR DESCRIPTION
Hey John,

The settings form action uses `esc_attr()` on the URL returned by `$this->admin_url()`. For URL-context attributes — `href`, `src`, `action` — `esc_url()` is the correct function. It validates and normalises the URL in addition to encoding it for HTML output. `esc_attr()` only handles the HTML attribute encoding side. WordPress Plugin Check flags this pattern.

One-character change on one line.

(full disclosure, I used AI help with the testing and tweaks - Christopher)
